### PR TITLE
Build against Eclipse 2024-06/JavaSE-17 by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 
   tools {
     maven 'apache-maven-latest'
-    jdk 'temurin-jdk${targetPlatformToJavaVersionMap[params.TARGET_PLATFORM]}-latest'
+    jdk 'temurin-jdk' + targetPlatformToJavaVersionMap[params.TARGET_PLATFORM] + '-latest'
   }
 
   environment {


### PR DESCRIPTION
2024-09 builds with JavaSE-21, which breaks backward compatiblity with older versions of Java (java.lang.NoClassDefFoundError: java/util/SequencedCollection)