### PR TITLE
Fix promotion

### DIFF
--- a/releng/org.eclipse.m2m.atl.releng.parent/promotion/pom.xml
+++ b/releng/org.eclipse.m2m.atl.releng.parent/promotion/pom.xml
@@ -28,7 +28,7 @@ SPDX-License-Identifier: EPL-2.0
   <packaging>pom</packaging>
 
   <properties>
-    <eclipse.repo>https://download.eclipse.org/releases/2023-09</eclipse.repo>
+    <eclipse.repo>https://download.eclipse.org/releases/${target-platform}</eclipse.repo>
     <justj.tools.repo>https://download.eclipse.org/justj/tools/updates/nightly/latest</justj.tools.repo>
     <org.eclipse.storage.user>genie.atl</org.eclipse.storage.user>
     <org.eclipse.justj.p2.manager.args>-remote ${org.eclipse.storage.user}@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/mmt/atl</org.eclipse.justj.p2.manager.args>


### PR DESCRIPTION
Cannot resolve project dependencies:
  Software being installed: org.eclipse.justj.p2 0.1.0.v20240522-0710
  Missing requirement: org.eclipse.justj.codegen 0.1.0.v20240802-1045
requires 'osgi.bundle; org.apache.commons.commons-io [2.16.1,3.0.0)' but it could not be found
  Cannot satisfy dependency: org.eclipse.justj.p2 0.1.0.v20240522-0710
depends on: osgi.bundle; org.eclipse.justj.codegen 0.0.0