### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/examples/org.eclipse.m2m.atl.examples/src/org/eclipse/m2m/atl/examples/AbstractExampleWizard.java
+++ b/examples/org.eclipse.m2m.atl.examples/src/org/eclipse/m2m/atl/examples/AbstractExampleWizard.java
@@ -179,6 +179,10 @@ public abstract class AbstractExampleWizard extends Wizard implements INewWizard
 				// created the destination project for this zip.
 				final File file = new File(project.getLocation().toString(), zipEntry.getName().replaceFirst(
 						"^" + regexedProjectName + "/", "")); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+				final File normalizedFile = file.toPath().normalize().toFile();
+				if (!normalizedFile.toPath().startsWith(project.getLocation().toString())) {
+					throw new IOException("Bad zip entry: " + zipEntry.getName());
+				}
 
 				if (!zipEntry.isDirectory()) {
 


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-atl/atl/security/code-scanning/1](https://github.com/eclipse-atl/atl/security/code-scanning/1)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This can be achieved by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. 

1. Normalize the path of the file created from the zip entry.
2. Check if the normalized path starts with the destination directory path.
3. If the check fails, throw an exception to prevent writing the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
